### PR TITLE
modification of command `ncm-cli policy add/del`

### DIFF
--- a/commands/policy.js
+++ b/commands/policy.js
@@ -19,15 +19,24 @@ function policy (argv) {
   const cmd = (argv) => {
     let action = (argv['_'][1] ? argv['_'][1].toLowerCase() : null)
 
+    let subaction = (argv['_'][2] ? argv['_'][2].toLowerCase() : null)
+
     switch (action) {
-      case 'add':
-        modifyWhitelistEntries(action, parseEntries(argv))
-        break
-      case 'del':
-        modifyWhitelistEntries(action, parseEntries(argv))
-        break
       case 'whitelist':
-        getWhitelist()
+        switch (subaction) {
+          case null:
+            getWhitelist()
+            break
+          case 'add':
+            modifyWhitelistEntries(subaction, parseEntries(argv))
+            break
+          case 'del':
+            modifyWhitelistEntries(subaction, parseEntries(argv))
+            break
+          default:
+            displayHelp('policy')
+            break
+        }
         break
       default:
         displayHelp('policy')
@@ -137,9 +146,9 @@ const parseEntries = (argv) => {
   let entries = []
 
   argv['_'].forEach((pkg, ind) => {
-    if (ind > 1 && pkg.includes('@')) {
+    if (ind > 2 && pkg.includes('@')) {
       entries.push({ name: pkg.split('@')[0], version: pkg.split('@')[1] })
-    } else if (ind > 1) {
+    } else if (ind > 2) {
       logger([{ text: 'Unable to determine package: ', style: [] }, { text: `${pkg}`, style: 'error' }])
     }
   })

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -178,8 +178,8 @@ function displayHelp (cmd) {
       break
     case 'policy':
       logger([{ text: `ncm-cli policy whitelist`, style: [] }])
-      logger([{ text: `ncm-cli policy add <pkg-name>@<ver>`, style: [] }])
-      logger([{ text: `ncm-cli policy del <pkg-name>@<ver>`, style: [] }])
+      logger([{ text: `ncm-cli policy whitelist add <pkg-name>@<ver>`, style: [] }])
+      logger([{ text: `ncm-cli policy whitelist del <pkg-name>@<ver>`, style: [] }])
       break
     case 'verify':
       logger([{ text: `ncm-cli verify [options]`, style: [] }])


### PR DESCRIPTION
To further distinguish the action of the user, the existing command has been modified:
`ncm-cli policy add <pkg>@<ver>`

The new policy command structure will be composed of subcommands corresponding to their respective operation on the active policy set, beginning with `whitelist`. 

```
ncm-cli policy whitelist   (fetch and display the whitelist for the active policy set)
ncm-cli policy whitelist add <pkg>@<ver>
ncm-cli policy whitelist del <pkg>@<ver>
```