### PR TITLE
Verify - Directory crawling and output functionality

### DIFF
--- a/commands/verify.js
+++ b/commands/verify.js
@@ -2,8 +2,6 @@
 
 'use strict'
 
-const path = require('path')
-
 const analyze = require('ncm-analyze-tree')
 const { getTokens } = require('../lib/config')
 const {
@@ -12,7 +10,8 @@ const {
   outputReport,
   handleError,
   refreshSession,
-  displayHelp
+  displayHelp,
+  crawlDir
 } = require('../lib/tools')
 
 module.exports = verify
@@ -40,8 +39,8 @@ function verify (argv) {
 }
 
 const crawl = async ({ session }, dir) => {
-  // start position logic
-  if (!dir) dir = path.join(__dirname, '..')
+  if (!dir) dir = crawlDir(__dirname)
+  else dir = crawlDir(dir)
 
   const f = new Set()
   const r = new Set()

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -20,7 +20,8 @@ module.exports = {
   handleError: handleError,
   handleReadline: handleReadline,
   refreshSession: refreshSession,
-  displayHelp: displayHelp
+  displayHelp: displayHelp,
+  crawlDir: crawlDir
 }
 
 function makeRequest (options, fn) {
@@ -147,6 +148,22 @@ function handleReadline (question, fn) {
     fn(d)
     rl.close()
   })
+}
+
+function crawlDir (cd) {
+  var parent = path.join(cd, '..')
+  var parentOfParent = path.join(cd, '../..')
+
+  let x = [
+    fs.existsSync(`${parent}/package.json`),
+    fs.existsSync(`${parentOfParent}/package.json`)
+  ]
+
+  if (!x[0] && !x[0]) {
+    return cd
+  } else {
+    return crawlDir(parent)
+  }
 }
 
 function displayHelp (cmd) {


### PR DESCRIPTION
## Changes
1. Introduced crawling logic when deciding where to start when verifying the dependency tree. This occurs when a user runs the command `ncm-cli verify` without specifying a directory.
(i.e. `ncm-cli verify -d ./`)
2. Resolved error with outputting the score report. Output will be written to current directory if no directory is passed using the `--output, -o` option. (`ncm-cli verify -o ~/Desktop`)