### PR TITLE
Signin - Username / Password handled via readline

### DIFF
--- a/commands/signin.js
+++ b/commands/signin.js
@@ -2,7 +2,13 @@
 
 'use strict'
 
-const { makeRequest, handleError, handleReadline, displayHelp } = require('../lib/tools')
+const {
+  makeRequest,
+  handleError,
+  handleReadline,
+  handleHiddenReadline,
+  displayHelp
+} = require('../lib/tools')
 const { setValue, getTokens, setTokens, api } = require('../lib/config')
 const logger = require('../lib/logger')
 
@@ -16,30 +22,20 @@ function signin (argv) {
     return true
   }
 
-  // todo: deturd
-  let args = argv['_'] || null
-
   let SSO =
         (argv['G'] ? 'google' : null) ||
         (argv['g'] ? 'github' : null) ||
         null
 
-  if (args && args.length === 3) {
-    let email = (args[1].length > 0 ? args[1] : null)
-    let password = (args[1].length > 0 ? args[2] : null)
-
-    if (email && password) {
-      try {
-        emailAuth(JSON.stringify({ email, password }))
-      } catch (err) {
-        handleError('Signin::InvalidLoginCredentials')
-      }
-    }
+  if (argv['_'].length !== 1) {
+    handleError('Signin::InvalidMethod')
   }
 
   if (SSO) {
     getUrlSSO(SSO)
   }
+
+  promptEmailSignin()
 
   return true
 }
@@ -54,6 +50,18 @@ function emailAuth (usrInfo) {
   }
 
   makeRequest(options, onSession)
+}
+
+function promptEmailSignin () {
+  handleReadline('email: ', email => {
+    handleHiddenReadline('password: ', password => {
+      try {
+        emailAuth(JSON.stringify({ email, password }))
+      } catch (err) {
+        handleError('Signin::InvalidLoginCredentials')
+      }
+    })
+  })
 }
 
 function getUrlSSO (sso) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -19,6 +19,7 @@ module.exports = {
   outputReport: outputReport,
   handleError: handleError,
   handleReadline: handleReadline,
+  handleHiddenReadline: handleHiddenReadline,
   refreshSession: refreshSession,
   displayHelp: displayHelp
 }
@@ -144,15 +145,45 @@ function refreshSession () {
   makeRequest(options, handleError)
 }
 
-function handleReadline (question, fn) {
+function handleReadline (query, fn) {
   let rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
   })
 
-  rl.question(question, (d) => {
-    fn(d)
+  rl.question(query, (d) => {
     rl.close()
+    fn(d)
+  })
+}
+
+function handleHiddenReadline (query, fn) {
+  const stdin = process.openStdin()
+  const hidden = readline.createInterface({
+    input: stdin,
+    output: process.stdout
+  })
+  function onData (char) {
+    char = char.toString()
+    switch (char) {
+      case '\n':
+      case '\r':
+      case '\u0004':
+        stdin.removeListener('data', onData)
+        break
+      default:
+        process.stdout.write('\u001b[2K\u001b[200D' + query +
+          Array(hidden.line.length + 1).join('*'))
+        break
+    }
+  }
+
+  stdin.on('data', onData)
+
+  hidden.question(query, value => {
+    hidden.history = hidden.history.slice(1)
+    hidden.close()
+    fn(value)
   })
 }
 
@@ -247,4 +278,5 @@ function handleError (err) {
       logger([{ text: err, style: 'error' }])
       break
   }
+  process.exit(1)
 }


### PR DESCRIPTION
### Previously:
Username and password was originally passed in a single line command:
`ncm-cli signin username password`

### Now:
Following the flow of `nscm`, we now prompt users for their username and password after entering the command:
```
$ ncm-cli signin
email: foo@bar.io
password: **********
```

Password is hidden from view using the `hidden()` function from `nscm` found [here](https://github.com/nodesource/nscm/blob/73eb52a1961f0099f7328be65c1db9a0f5471c0f/commands/signin.js#L185).