### PR TITLE
vendor ncm-analyze-tree using api v2

### DIFF
--- a/lib/ncm-analyze-tree.js
+++ b/lib/ncm-analyze-tree.js
@@ -1,0 +1,126 @@
+'use strict'
+
+const { graphql } = require('./util')
+const semver = require('semver')
+const universalModuleTree = require('universal-module-tree')
+
+const analyze = async ({
+  dir,
+  token,
+  pageSize: pageSize = 50,
+  concurrency: concurrency = 5,
+  onPkgs: onPkgs = () => {},
+  filter: filter = () => true,
+  url
+}) => {
+  const pkgs = filterPkgs(await readUniversalTree(dir), filter)
+  onPkgs(pkgs)
+  let data = new Set()
+  const pages = splitSet(pkgs, pageSize)
+  const batches = splitSet(pages, concurrency)
+  for (const batch of batches) {
+    await Promise.all([...batch].map(async page => {
+      for (const datum of await fetchData({ pkgs: page, token, url })) {
+        data.add(datum)
+      }
+    }))
+  }
+  return data
+}
+
+const filterPkgs = (pkgs, fn) => {
+  const map = new Map()
+  for (const pkg of pkgs) {
+    const id = `${pkg.name}${pkg.version}`
+    if (semver.valid(pkg.version) && !map.get(id) && fn(pkg)) {
+      map.set(id, pkg)
+    }
+  }
+
+  const clean = new Set()
+  for (const [, pkg] of map) clean.add(pkg)
+  return clean
+}
+
+const id = node => `${node.data.name}@${node.data.version}`
+
+const readUniversalTree = async dir => {
+  const tree = await universalModuleTree(dir)
+  const pkgs = new Map()
+
+  const walk = (node, path) => {
+    let pkgObj
+    if (pkgs.has(id(node))) {
+      pkgObj = pkgs.get(id(node))
+      pkgObj.paths.push(path)
+    } else {
+      pkgObj = {
+        name: node.data.name,
+        version: node.data.version,
+        paths: [path]
+      }
+      pkgs.set(id(node), pkgObj)
+      for (const child of node.children) {
+        walk(child, [...path, node])
+      }
+    }
+  }
+
+  for (const child of tree.children) {
+    walk(child, [])
+  }
+
+  const set = new Set()
+  for (const [, pkg] of pkgs) set.add(pkg)
+  return set
+}
+
+const fetchData = async ({ pkgs, token, url }) => {
+  const query = `
+    query getPackageVersions($packageVersions: [PackageVersionInput!]!) {
+      packageVersions(packageVersions: $packageVersions) {
+        name
+        version
+        published
+        publishedAt
+        scores {
+          group
+          name
+          pass
+          severity
+          title
+          data
+        }
+      }
+    }
+  `
+
+  const variables = {
+    packageVersions: [...pkgs].map(({ name, version }) => ({ name, version }))
+  }
+
+  const res = await graphql({ token, url }, query, variables)
+  const data = new Set()
+  for (const datum of res.packageVersions) {
+    // datum.paths = [...pkgs][i].paths
+    data.add(datum)
+  }
+  return data
+}
+
+const splitSet = (set, n) => {
+  const buckets = new Set()
+  let bucket
+  for (const member of set) {
+    if (!bucket) bucket = new Set()
+    bucket.add(member)
+    if (bucket.size === n) {
+      buckets.add(bucket)
+      bucket = null
+    }
+  }
+  if (bucket) buckets.add(bucket)
+  return buckets
+}
+
+module.exports = analyze

--- a/lib/report.js
+++ b/lib/report.js
@@ -11,6 +11,21 @@ const fsPromises = {
 const logger = require('./logger')
 const { handleError } = require('./util')
 
+const SEVERITY_RMAP = [
+  'None',
+  'Low',
+  'Medium',
+  'High',
+  'Critical'
+]
+const SEVERITY_STYLE = [
+  [], // None
+  ['bold'], // Low
+  ['yellow', 'bold'], // Medium
+  ['red', 'bold'], // High
+  ['redBright', 'underline', 'bold'] // Critical
+]
+
 module.exports = {
   scoreReport,
   jsonReport,
@@ -38,8 +53,9 @@ function scoreReport (report) {
     { text: `${' '.repeat(Math.floor(width * 0.50 - (pkg.name.length)))}|`, style: 'table' },
     { text: `${' '.repeat(width * 0.05)}${pkg.version}`, style: [] },
     { text: `${' '.repeat(Math.floor(width * 0.20 - (pkg.version.length) - 1))}|`, style: 'table' },
-    { text: `${' '.repeat(width * 0.05)}${pkg.score}`, style: pkg.score < 50 ? ['red', 'bold'] : [] },
-    { text: `${' '.repeat(width * 0.10 + 3 - String(pkg.score).length)}║`, style: 'table' }
+    { text: `${' '.repeat(width * 0.05)}`, style: [] },
+    { text: `${SEVERITY_RMAP[pkg.maxSeverity]}`, style: SEVERITY_STYLE[pkg.maxSeverity] },
+    { text: `${' '.repeat(width * 0.10 + 3 - SEVERITY_RMAP[pkg.maxSeverity].length)}║`, style: 'table' }
   ])
 
   logger([{ text: 'NCM-CLI', style: 'ncm' }])
@@ -47,6 +63,7 @@ function scoreReport (report) {
   loggerTableTitle()
   for (const pkg of report) {
     if (pkg.name.length > width * 0.40) pkg.name = `${pkg.name.slice(0, width * 0.40)}..`
+    if (pkg.version === null) continue // Probably a private package
     loggerBar()
     loggerPackageDetails(pkg)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2106,16 +2106,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "ncm-analyze-tree": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ncm-analyze-tree/-/ncm-analyze-tree-3.0.0.tgz",
-      "integrity": "sha512-CVUfKOI2kx5w1gEatDv8oSZSjwxOxWh485M1mW/U0V12nouDH4Cb7j23X1DCTgxDwp64dytWIWVcpzeHbNQEtA==",
-      "requires": {
-        "graphql-request": "^1.8.2",
-        "semver": "^5.5.1",
-        "universal-module-tree": "^2.0.0"
-      }
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "client-request": "^2.3.0",
     "configstore": "^4.0.0",
     "graphql-request": "^1.8.2",
-    "ncm-analyze-tree": "^3.0.0",
     "p-defer": "^1.0.0",
+    "semver": "^5.6.0",
+    "universal-module-tree": "^2.0.0",
     "yargs": "^12.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds a modified version of ncm-analyze-tree updated to use NCM api v2.

Now returns the new scores and score severity in verify reports.

-----

Example `verify report` output:

<img width="621" alt="screen shot 2018-12-20 at 11 27 57 am" src="https://user-images.githubusercontent.com/1093990/50306420-5b750f00-044a-11e9-81c2-c05cebd6418c.png">
