### PR TITLE
signin,orgs: refactor to use new output style + more

### DIFF
--- a/lib/ncm-style.js
+++ b/lib/ncm-style.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const util = require('util')
+const chalk = require('chalk')
+
+// Colors
+const light1 = 'hex(\'#89a19d\')'
+const blue = 'hex(\'#4cb5ff\')'
+const green = 'hex(\'#5ac878\')'
+const yellow = 'hex(\'#ffb726\')'
+const red = 'hex(\'#ff6040\')'
+
+module.exports = {
+  // colors
+  light1,
+  blue,
+  green,
+  yellow,
+  red,
+
+  // formatted printers
+  header,
+  line,
+  box,
+  boxbox,
+  formatError
+}
+
+// Formatted printers
+function header (text) {
+  const { length } = text
+  return chalk`
+{${light1} ╔══${'═'.repeat(length)}╗}
+{${light1} ║} {white ${text}} {${light1} ║}
+{${light1} ╚══${'═'.repeat(length)}╝}
+  `.trim()
+}
+
+function line (symbol, text, color = light1) {
+  return chalk`{${color} ${symbol}} ${text}`
+}
+
+function box (symbol, text, color = light1) {
+  const { length } = text
+  return chalk`
+{${color} ┌───${'─'.repeat(length)}─┐}
+{${color} │ ${symbol}} {white ${text}} {${color} │}
+{${color} └───${'─'.repeat(length)}─┘}
+  `.trim()
+}
+
+function boxbox (symbol, text, color = light1) {
+  const { length } = text
+  return chalk`
+{${color} ┌───┬─${'─'.repeat(length)}─┐}
+{${color} │ ${symbol} │} {white ${text}} {${color} │}
+{${color} └───┴─${'─'.repeat(length)}─┘}
+  `.trim()
+}
+
+function formatError (message, err) {
+  if (process.env['NCM_DEV'] === 'true' && err) {
+    message = util.format(message, err.message || err)
+  }
+  return line('‼︎', chalk`{${red} ${message}}`, red)
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,6 +14,7 @@ module.exports = {
   graphql,
   handleError,
   queryReadline,
+  queryReadlineHidden,
   refreshSession
 }
 
@@ -64,6 +65,30 @@ function queryReadline (query) {
     deferred.resolve(answer)
     rl.close()
   })
+
+  return deferred.promise
+}
+
+// For passwords
+function queryReadlineHidden (query) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  })
+
+  const deferred = pDefer()
+  rl.question(query, answer => {
+    deferred.resolve(answer)
+    rl.close()
+  })
+
+  // This is an unpleasant hack.
+  // This functionality belongs in Node core.
+  const _writeToOutput = rl._writeToOutput.bind(rl)
+  rl._writeToOutput = function _writeHiddenToOutput (stringToWrite) {
+    // XXX(Jeremiah): Ideally ignore any escape character
+    _writeToOutput('*')
+  }
 
   return deferred.promise
 }


### PR DESCRIPTION
As seen in the zeplin designs.

Also adds some nicer utilities for printing our style, based on the work done in #41 but made nicer.

Other notes:
- Signin now prompts for email and hidden pass.
- The org selection is re-used in the signin command.
- Org selection now has a default.
- boxbox is the most proud I've ever been for naming a function.

Part of https://github.com/nodesource/ncm-cli/issues/36

-----

Addendum: this accidentally clobbers most of https://github.com/nodesource/ncm-cli/pull/19, but there is still value over there on the hidden readline prompt that we can PR on top of this.