### PR TITLE
pkg: bump universal-module-tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1984,8 +1984,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -2396,9 +2395,9 @@
       }
     },
     "read-package-tree": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.1.tgz",
-      "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz",
+      "integrity": "sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==",
       "requires": {
         "debuglog": "^1.0.1",
         "dezalgo": "^1.0.0",
@@ -3104,12 +3103,23 @@
       }
     },
     "universal-module-tree": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universal-module-tree/-/universal-module-tree-2.0.0.tgz",
-      "integrity": "sha512-scLhUodzjP30YlyRIAhuRefXsADOF0uZLvtHMF1DVjNg+Yhklb6iXgaRNpJh7WPK4fs8Esfyf1PPrQpfdFRlXA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/universal-module-tree/-/universal-module-tree-3.0.1.tgz",
+      "integrity": "sha512-gIwEWe7hchkU3uLTJUVLeMgZ7zNZMp7nOidmB7QVklkjAZq+MaIYPZ3G0h+vlFL6PLwzleZggEw+2wW9fL4PRA==",
       "requires": {
         "@yarnpkg/lockfile": "^1.1.0",
+        "debug": "^4.1.1",
         "read-package-tree": "^5.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "unset-value": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "minimist": "^1.2.0",
     "p-defer": "^1.0.0",
     "semver": "^5.6.0",
-    "universal-module-tree": "^2.0.0"
+    "universal-module-tree": "^3.0.1"
   },
   "devDependencies": {
     "dependency-check": "^3.2.1",


### PR DESCRIPTION
This fixes usage of ncm-cli with repos that don't have a lockfile.