### PR TITLE
report output: dont print unnecessary command

### DIFF
--- a/lib/report/short.js
+++ b/lib/report/short.js
@@ -13,14 +13,6 @@ const chalk = require('chalk')
 const L = console.log
 
 function shortReport (report, whitelist, dir, argv) {
-  summary(report, dir)
-
-  if (whitelist.length > 0) {
-    L(chalk`  {${COLORS.yellow} !} ${whitelist.length} used modules whitelisted`)
-    L('    ' + tooltip('Run `ncm whitelist --list` for a list'))
-    L()
-  }
-
   let filterSecurity = argv ? !!argv.security : false
   let filterCompliance = argv ? !!argv.compliance : false
   let filterLevel = SEVERITY_RMAP.indexOf('NONE')
@@ -49,13 +41,21 @@ function shortReport (report, whitelist, dir, argv) {
     }
   }
 
-  if (filterCompliance || filterSecurity || filterLevel > 0) {
-    const filterOptions = {
-      filterCompliance: filterCompliance,
-      filterSecurity: filterSecurity,
-      filterLevel: filterLevel
-    }
+  const filterOptions = {
+    filterCompliance: filterCompliance,
+    filterSecurity: filterSecurity,
+    filterLevel: filterLevel
+  }
 
+  summary(report, dir, filterOptions)
+
+  if (whitelist.length > 0) {
+    L(chalk`  {${COLORS.yellow} !} ${whitelist.length} used modules whitelisted`)
+    L('    ' + tooltip('Run `ncm whitelist --list` for a list'))
+    L()
+  }
+
+  if (filterCompliance || filterSecurity || filterLevel > 0) {
     const filterFormat = formatFilterOptions(filterOptions)
     if (whitelist.length > 0) {
       moduleList(

--- a/lib/report/summary.js
+++ b/lib/report/summary.js
@@ -12,7 +12,9 @@ const {
 const L = console.log
 const chalk = require('chalk')
 
-function summary (report, dir) {
+function summary (report, dir, filterOptions) {
+  filterOptions = filterOptions || {}
+
   L()
   L(chalk`${report.length} {${COLORS.light1} packages checked}`)
   L()
@@ -47,14 +49,18 @@ function summary (report, dir) {
   L()
   if (securityCount) {
     L(chalk`  {${COLORS.red} !} ${securityCount} security vulnerabilities found across ${insecureModules} modules`)
-    L('    ' + tooltip('Run `ncm report --filter=security` for a list'))
+    if (!filterOptions.filterSecurity) {
+      L('    ' + tooltip('Run `ncm report --filter=security` for a list'))
+    }
   } else {
     L(chalk`  {${COLORS.green} ✓} No security vulnerabilities found`)
   }
   L()
   if (complianceCount) {
     L(chalk`  {${COLORS.red} !} ${complianceCount} noncompliant modules found`)
-    L('    ' + tooltip('Run `ncm report --filter=compliance` for a list'))
+    if (!filterOptions.filterCompliance) {
+      L('    ' + tooltip('Run `ncm report --filter=compliance` for a list'))
+    }
   } else {
     L(chalk`  {${COLORS.green} ✓} All modules compliant`)
   }

--- a/tap-snapshots/test-report.js-TAP.test.js
+++ b/tap-snapshots/test-report.js-TAP.test.js
@@ -55,7 +55,6 @@ exports[`test/report.js TAP report --compliance output > report-output-complianc
     [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
 
 [38;2;137;161;157m─────────────────────────────────────────────────────────────────────────────────────────────────[39m
 [38;2;137;161;157m  Filtered Modules (--filter=compliance)[39m
@@ -85,7 +84,6 @@ exports[`test/report.js TAP report -c output > report-output-compliance 1`] = `
     [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
 
 [38;2;137;161;157m─────────────────────────────────────────────────────────────────────────────────────────────────[39m
 [38;2;137;161;157m  Filtered Modules (--filter=compliance)[39m
@@ -115,7 +113,6 @@ exports[`test/report.js TAP report --filter=compliance output > report-output-co
     [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
 
 [38;2;137;161;157m─────────────────────────────────────────────────────────────────────────────────────────────────[39m
 [38;2;137;161;157m  Filtered Modules (--filter=compliance)[39m
@@ -142,7 +139,6 @@ exports[`test/report.js TAP report --security output > report-output-security 1`
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
@@ -174,7 +170,6 @@ exports[`test/report.js TAP report -s output > report-output-security 1`] = `
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
@@ -206,7 +201,6 @@ exports[`test/report.js TAP report --filter=security output > report-output-secu
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
@@ -238,7 +232,6 @@ exports[`test/report.js TAP report --filter=high --security output > report-outp
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
@@ -325,7 +318,6 @@ exports[`test/report.js TAP report --filter=high,security output > report-output
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
@@ -354,7 +346,6 @@ exports[`test/report.js TAP report --filter=medium --security output > report-ou
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
@@ -384,7 +375,6 @@ exports[`test/report.js TAP report --filter=m --security output > report-output-
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
@@ -414,7 +404,6 @@ exports[`test/report.js TAP report --filter=low --security output > report-outpu
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m
@@ -446,7 +435,6 @@ exports[`test/report.js TAP report --filter=l --security output > report-output-
     [38;2;137;161;157m13[39m low risk
 
   [38;2;255;96;64m![39m 4 security vulnerabilities found across 4 modules
-    [38;2;102;204;187m|➔ Run \`ncm report --filter=security\` for a list[39m
 
   [38;2;255;96;64m![39m 2 noncompliant modules found
     [38;2;102;204;187m|➔ Run \`ncm report --filter=compliance\` for a list[39m


### PR DESCRIPTION
If you run `report --filter=compliance` it still tells you
to run it again

Fixes #113