### PR TITLE
bump universal-module-tree. closes #115

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6011,9 +6011,9 @@
       }
     },
     "universal-module-tree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/universal-module-tree/-/universal-module-tree-3.0.1.tgz",
-      "integrity": "sha512-gIwEWe7hchkU3uLTJUVLeMgZ7zNZMp7nOidmB7QVklkjAZq+MaIYPZ3G0h+vlFL6PLwzleZggEw+2wW9fL4PRA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/universal-module-tree/-/universal-module-tree-3.0.2.tgz",
+      "integrity": "sha512-IoCJ4sfN8iMoXDgpkClLXcH8mxFxMJycpo/14ZWcg5OTfnBlRVYSrSIKRdZcSBGRnE3HQpie3RPO8km06i+YpA==",
       "requires": {
         "@yarnpkg/lockfile": "^1.1.0",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "minimist": "^1.2.0",
     "p-defer": "^1.0.0",
     "semver": "^5.6.0",
-    "universal-module-tree": "^3.0.1",
+    "universal-module-tree": "^3.0.2",
     "update-notifier": "^2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
```bash
 λ  ncm-cli (master) : ./bin/ncm-cli.js report ~/dev/facebook/react/

╔══════════════╗
║ react Report ║
╚══════════════╝

779 packages checked

  ! 0 critical risk
    47 high risk
    93 medium risk
    201 low risk

  ! 15 security vulnerabilities found across 14 modules
    |➔ Run `ncm report --filter=security` for a list

  ! 6 noncompliant modules found
    |➔ Run `ncm report --filter=compliance` for a list

─────────────────────────────────────────────────────────────────────────────────────────────────
  Top 5: Highest Risk Modules
-------------------------------------------------------------------------------------------------
  Module Name                               Risk         License                 Security
┌──────────────────────────────────────────┬────────────┬───────────────────────┬───────────────┐
│ @mattiasbuelens/web-streams-pol… @ 0.1.0 │ |||| High  │ ✓ MIT                 │ ✓ 0           │
│ async @ 2.6.1                            │ |||| High  │ ✓ MIT                 │ ✓ 0           │
│ boom @ 2.10.1                            │ |||| High  │ ✓ BSD-3-Clause        │ ✓ 0           │
│ browser-resolve @ 1.11.2                 │ |||| High  │ ✓ MIT                 │ ✓ 0           │
│ circular-json @ 0.3.1                    │ |||| High  │ ✓ MIT                 │ ✓ 0           │
└──────────────────────────────────────────┴────────────┴───────────────────────┴───────────────┘
```