### PR TITLE
queryReadlineHidden: do it properly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -142,8 +142,22 @@ function queryReadlineHidden (query) {
   // This functionality belongs in Node core.
   const _writeToOutput = rl._writeToOutput.bind(rl)
   rl._writeToOutput = function _writeHiddenToOutput (stringToWrite) {
-    // XXX(Jeremiah): Ideally ignore any escape character
-    _writeToOutput('*')
+    let newStr = ''
+    // Do not interfere with a prompt.
+    if (this._prompt && stringToWrite.startsWith(this._prompt)) {
+      stringToWrite = stringToWrite.substring(this._prompt.length)
+      newStr += this._prompt
+    }
+    // Iterate and reconstruct word characters (including spaces) to hide.
+    for (let char of stringToWrite) {
+      if (/^[\S ]+$/.test(char)) {
+        char = '*'
+      }
+      newStr += char
+    }
+    stringToWrite = newStr
+
+    _writeToOutput(stringToWrite)
   }
 
   return deferred.promise


### PR DESCRIPTION
This handles non-word characters correctly, and is very similar to a patch I will be submitting to node core.

Closes https://github.com/nodesource/ncm-cli/pull/19