### PR TITLE
ci: update nodejs versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  - "11"
+  - "12"
 matrix:
   include:
-    - node_js: "12"
+    - node_js: "13"
       env: "NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/nightly"
   allow_failures:
     # Allow the nightly installs to fail


### PR DESCRIPTION
12 has been stable a couple months, 13 is master.