### PR TITLE
update to standard@13

### DIFF
--- a/bin/ncm-cli.js
+++ b/bin/ncm-cli.js
@@ -40,7 +40,7 @@ async function main () {
     }
   })
 
-  let [ command = 'help', ...subargs ] = argv._
+  let [command = 'help', ...subargs] = argv._
   if (!Object.keys(commands).includes(command)) {
     command = 'help'
   }

--- a/commands/config.js
+++ b/commands/config.js
@@ -108,7 +108,7 @@ async function config (argv, action, key, value) {
     case 'list':
       const { unhide } = argv
 
-      for (let key of keyNames) {
+      for (const key of keyNames) {
         let val = getValue(key)
 
         if (val.trim() === '') {

--- a/commands/details.js
+++ b/commands/details.js
@@ -122,7 +122,7 @@ async function details (argv, arg1, arg2, arg3) {
     return
   }
 
-  let report = Object.assign({ failures: [], requirePaths }, data.packageVersion)
+  const report = Object.assign({ failures: [], requirePaths }, data.packageVersion)
 
   /* NCM-Cli Header */
   // later than usual so we can pick up the actual version.

--- a/commands/orgs.js
+++ b/commands/orgs.js
@@ -48,8 +48,8 @@ async function orgs (argv, org) {
 }
 
 async function orgsCli (details, org) {
-  const orgs = [ 'personal' ]
-  for (let orgId in details.orgs) {
+  const orgs = ['personal']
+  for (const orgId in details.orgs) {
     if (details.orgs[orgId].expired === true) return
     orgs.push(details.orgs[orgId].name)
   }

--- a/commands/signin.js
+++ b/commands/signin.js
@@ -76,17 +76,14 @@ async function signin (argv, email, password) {
     }
   } else {
     while (!authData) {
-      let email
-      let password
-
       L(line('|➔', 'Enter your NodeSource credentials:', COLORS.yellow))
       L()
 
       L(line('?', 'Email:', COLORS.red))
-      email = (await queryReadline(chalk`{${COLORS.light1} > }`)).trim()
+      const email = (await queryReadline(chalk`{${COLORS.light1} > }`)).trim()
       L()
       L(line('?', 'Password:', COLORS.red))
-      password = (await queryReadlineHidden(chalk`{${COLORS.light1} > }`)).trim()
+      const password = (await queryReadlineHidden(chalk`{${COLORS.light1} > }`)).trim()
 
       const usrInfo = JSON.stringify({ email, password })
 

--- a/commands/whitelist.js
+++ b/commands/whitelist.js
@@ -87,7 +87,7 @@ async function whitelist (argv) {
   if (list && typeof list === 'boolean') {
     whitelistList()
   } else if (add || remove) {
-    const input = add ? [ add, ...argv._.slice(1) ] : [ remove, ...argv._.slice(1) ]
+    const input = add ? [add, ...argv._.slice(1)] : [remove, ...argv._.slice(1)]
     const entries = prepareInput(input)
 
     if (entries.length === 0) {
@@ -176,7 +176,7 @@ async function whitelist (argv) {
         if (!score.pass) {
           failures.push(score)
           if (score.group === 'risk') {
-            let riskSeverity = SEVERITY_RMAP.indexOf(score.severity)
+            const riskSeverity = SEVERITY_RMAP.indexOf(score.severity)
             if (riskSeverity > maxSeverity) maxSeverity = riskSeverity
           }
         }
@@ -208,14 +208,14 @@ function prepareInput (input) {
         semver.valid(entry.split('@')[1])
     ) {
       /* pkg@ver */
-      let [ name, version ] = entry.split('@')
+      const [name, version] = entry.split('@')
       entries.push({ name, version })
     } else if (entry[0] === '@' &&
             Array.from(entry).filter(char => char === '@').length === 2 &&
             semver.valid(entry.substring(1).split('@')[1])
     ) {
       /* @namespace/pkg@ver */
-      let [ name, version ] = entry.substring(1).split('@')
+      const [name, version] = entry.substring(1).split('@')
       entries.push({ name: '@' + name, version })
     } else {
       if (entry.indexOf('@') < 0 &&

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,7 +30,7 @@ module.exports = {
 }
 
 const validateState = () => {
-  for (let key in keys) {
+  for (const key in keys) {
     if (!conf.get(key)) conf.set(key, keys[key])
   }
 }
@@ -80,7 +80,7 @@ function popValue (key) {
 function resetState () {
   validateState()
 
-  for (let key in keys) {
+  for (const key in keys) {
     conf.set(key, keys[key])
   }
 }

--- a/lib/ncm-analyze-tree.js
+++ b/lib/ncm-analyze-tree.js
@@ -15,7 +15,7 @@ const analyze = async ({
 }) => {
   const pkgs = filterPkgs(await readUniversalTree(dir), filter)
   onPkgs(pkgs)
-  let data = new Set()
+  const data = new Set()
   const pages = splitSet(pkgs, pageSize)
   const batches = splitSet(pages, concurrency)
   for (const batch of batches) {

--- a/lib/report/module.js
+++ b/lib/report/module.js
@@ -146,8 +146,8 @@ function moduleReport (report) {
       }
 
       if (title.length > maxLength) {
-        let words = title.split(' ')
-        let lines = ['', '']
+        const words = title.split(' ')
+        const lines = ['', '']
         for (const word of words) {
           if ((lines[0] + word).length > maxLength - 10) lines[1] += ` ${word}`
           else lines[0] += `${word} `
@@ -209,8 +209,8 @@ function severityTextLabel (severity) {
 }
 
 function lineWrap (str, maxLength, split = ' ') {
-  let words = str.split(split)
-  let lines = []
+  const words = str.split(split)
+  const lines = []
   let lineIdx = 0
   for (const word of words) {
     while ((lines[lineIdx] + word).length > maxLength) {

--- a/lib/report/util.js
+++ b/lib/report/util.js
@@ -24,11 +24,11 @@ const W = [
 ]
 
 const SEVERITY_COLOR = {
-  'CRITICAL': COLORS.red,
-  'HIGH': COLORS.orange,
-  'MEDIUM': COLORS.yellow,
-  'LOW': COLORS.light1,
-  'NONE': COLORS.base
+  CRITICAL: COLORS.red,
+  HIGH: COLORS.orange,
+  MEDIUM: COLORS.yellow,
+  LOW: COLORS.light1,
+  NONE: COLORS.base
 }
 
 module.exports = {
@@ -53,7 +53,7 @@ function filterReport (report, options) {
     return report
   }
 
-  let minimumSeverity = options.filterLevel
+  const minimumSeverity = options.filterLevel
   for (const pkg of report) {
     const hasComplianceFailure = pkg.scores.some(
       s => s.group === 'compliance' && !s.pass
@@ -121,7 +121,7 @@ function moduleList (report, title, options) {
         : chalk`{${COLORS.red} X}`
 
       /* security badge */
-      let vulns = [0, 0, 0, 0]
+      const vulns = [0, 0, 0, 0]
       for (const { group, severity } of pkg.failures) {
         if (group === 'security') {
           if (severity === 'CRITICAL') vulns[3]++
@@ -186,12 +186,12 @@ function moduleList (report, title, options) {
 }
 
 function shortVulnerabilityList (report) {
-  let netSecurity = {
-    'LOW': 0,
-    'MEDIUM': 0,
-    'HIGH': 0,
-    'CRITICAL': 0,
-    'AFFECTED': new Set()
+  const netSecurity = {
+    LOW: 0,
+    MEDIUM: 0,
+    HIGH: 0,
+    CRITICAL: 0,
+    AFFECTED: new Set()
   }
 
   for (const pkg of report) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,9 +179,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
-      "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
     "acorn-node": {
@@ -222,12 +222,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ajv-keywords": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-      "dev": true
-    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -237,9 +231,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -377,6 +371,12 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.4.tgz",
       "integrity": "sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw=="
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -400,59 +400,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -720,19 +667,10 @@
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "^0.2.0"
-      }
-    },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "camelcase": {
@@ -762,21 +700,15 @@
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -1076,7 +1008,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -1190,23 +1122,23 @@
       }
     },
     "deglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
-      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
+      "integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
       "dev": true,
       "requires": {
         "find-root": "^1.0.0",
         "glob": "^7.0.5",
-        "ignore": "^3.0.9",
+        "ignore": "^5.0.0",
         "pkg-config": "^1.1.0",
         "run-parallel": "^1.1.2",
         "uniq": "^1.0.1"
       },
       "dependencies": {
         "ignore": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
           "dev": true
         }
       }
@@ -1317,9 +1249,9 @@
       }
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -1391,16 +1323,17 @@
       }
     },
     "es-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
+        "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
@@ -1470,72 +1403,73 @@
       }
     },
     "eslint": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
-      "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz",
+      "integrity": "sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.0",
-        "babel-code-frame": "^6.26.0",
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
+        "espree": "^6.0.0",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
+        "glob-parent": "^3.1.0",
         "globals": "^11.7.0",
-        "ignore": "^4.0.2",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^5.2.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.11.0",
+        "inquirer": "^6.2.2",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
         "strip-ansi": "^4.0.0",
         "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
+        "table": "^5.2.3",
         "text-table": "^0.2.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "ajv": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         }
       }
     },
     "eslint-config-standard": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
-      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-13.0.1.tgz",
+      "integrity": "sha512-zLKp4QOgq6JFgRm1dDCVv1Iu0P5uZ4v5Wa4DTOkg2RFMxdCX/9Qf7lz9ezRj2dBRa955cWQF/O/LWEiYWAHbTw==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
-      "integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-7.0.0.tgz",
+      "integrity": "sha512-OiKOF3MFVmWOCVfsi8GHlVorOEiBsPzAnUhM3c6HML94O2krbdQ/eMABySHgHHOIBYRls9sR9I3lo6O0vXhVEg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -1566,13 +1500,13 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "pkg-dir": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1593,9 +1527,9 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.2.tgz",
-      "integrity": "sha512-xrdbConViY20DhGrt9FwjhDo4fr/9Yus2pYf0xJsdJaCcUzMq7+pAoNH7kSXF6V08bRHMpgDWclYbcr/Sn3hNg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
       "dev": true,
       "requires": {
         "eslint-utils": "^1.3.0",
@@ -1603,21 +1537,22 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.0.tgz",
+      "integrity": "sha512-PZpAEC4gj/6DEMMoU2Df01C5c50r7zdGIN52Yfi7CvvWaYssG7Jt5R9nFG5gmqodxNOz9vQS87xk6Izdtpdrig==",
       "dev": true,
       "requires": {
+        "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -1631,7 +1566,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -1644,40 +1579,96 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
     "eslint-plugin-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
-      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-9.1.0.tgz",
+      "integrity": "sha512-ZwQYGm6EoV2cfLpE1wxJWsfnKUIXfM/KM09/TlorkukgCAwmkgajEJnPCmyzoFPQQkmvo5DrW/nyKutNIw36Mw==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^1.3.1",
+        "eslint-plugin-es": "^1.4.0",
         "eslint-utils": "^1.3.1",
-        "ignore": "^4.0.2",
+        "ignore": "^5.1.1",
         "minimatch": "^3.0.4",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.0"
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-promise": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
-      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
-      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.2.tgz",
+      "integrity": "sha512-jZdnKe3ip7FQOdjxks9XPN0pjUKZYq48OggNMd16Sk+8VXx6JOvXmlElxROCgp7tiUsTsze3jd78s/9AFJP2mA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.2"
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "eslint-plugin-standard": {
@@ -1687,9 +1678,9 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1715,14 +1706,22 @@
       "dev": true
     },
     "espree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
+      "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
+        "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+          "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -1979,13 +1978,13 @@
       }
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
     },
@@ -2101,13 +2100,12 @@
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "file-uri-to-path": {
@@ -2224,16 +2222,21 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.7.0",
@@ -2389,9 +2392,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
     },
     "get-stream": {
@@ -2607,23 +2610,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2772,6 +2758,16 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "import-fresh": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -2802,24 +2798,58 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "5.2.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
+        "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "lodash": "^4.17.12",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
+        "rxjs": "^6.4.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "invert-kv": {
@@ -3049,12 +3079,6 @@
         "is-unc-path": "^1.0.0"
       }
     },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
-    },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -3256,9 +3280,9 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -3325,12 +3349,13 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3"
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
       }
     },
     "kind-of": {
@@ -3373,7 +3398,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -3385,7 +3410,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -3855,9 +3880,9 @@
       }
     },
     "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
     "object-visit": {
@@ -3869,6 +3894,42 @@
         "isobject": "^3.0.0"
       }
     },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
+      }
+    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -3876,6 +3937,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "on-finished": {
@@ -3992,7 +4065,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -4119,6 +4192,15 @@
         "semver": "^5.1.0"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -4190,7 +4272,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -4207,29 +4289,71 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+          "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
-    "pkg-conf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^4.0.0"
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -4239,18 +4363,6 @@
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
           }
         },
         "locate-path": {
@@ -4286,65 +4398,8 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
         }
       }
-    },
-    "pkg-config": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-      "dev": true,
-      "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "pkg-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true,
-      "requires": {
-        "find-up": "^1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        }
-      }
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -4370,19 +4425,20 @@
       "optional": true
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "proxy-addr": {
@@ -4495,6 +4551,12 @@
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
       }
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
     },
     "read-package-json": {
       "version": "2.0.13",
@@ -4707,16 +4769,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      }
-    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -4733,9 +4785,9 @@
       }
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "resolve-url": {
@@ -4784,12 +4836,12 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -4932,11 +4984,13 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
@@ -5209,40 +5263,32 @@
       "dev": true
     },
     "standard": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-12.0.1.tgz",
-      "integrity": "sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-13.0.2.tgz",
+      "integrity": "sha512-tcdJc7Oa+ZFpIcYqNaV3kG3Ikqk1Ir5dCn8vaiLWvDcXdRGvQVQGbTqW/3y4RPEHXGBXoZZRQbb6VbSGx+0aqg==",
       "dev": true,
       "requires": {
-        "eslint": "~5.4.0",
-        "eslint-config-standard": "12.0.0",
-        "eslint-config-standard-jsx": "6.0.2",
-        "eslint-plugin-import": "~2.14.0",
-        "eslint-plugin-node": "~7.0.1",
-        "eslint-plugin-promise": "~4.0.0",
-        "eslint-plugin-react": "~7.11.1",
+        "eslint": "~6.0.1",
+        "eslint-config-standard": "13.0.1",
+        "eslint-config-standard-jsx": "7.0.0",
+        "eslint-plugin-import": "~2.18.0",
+        "eslint-plugin-node": "~9.1.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.14.2",
         "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "~9.0.0"
+        "standard-engine": "~11.0.1"
       }
     },
     "standard-engine": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-9.0.0.tgz",
-      "integrity": "sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-11.0.1.tgz",
+      "integrity": "sha512-WZQ5PpEDfRzPFk+H9xvKVQPQIxKnAQB2cb2Au4NyTCtdw5R0pyMBUZLbPXyFjnlhe8Ae+zfNrWU4m6H5b7cEAg==",
       "dev": true,
       "requires": {
-        "deglob": "^2.1.0",
-        "get-stdin": "^6.0.0",
+        "deglob": "^3.0.0",
+        "get-stdin": "^7.0.0",
         "minimist": "^1.1.0",
-        "pkg-conf": "^2.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
+        "pkg-conf": "^3.1.0"
       }
     },
     "static-extend": {
@@ -5320,24 +5366,56 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
-    },
     "table": {
-      "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
-      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
+      "integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "tap": {
@@ -5548,7 +5626,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -5688,6 +5766,12 @@
       "integrity": "sha512-jxyxgKVKa4Bh5dPcO42TJL22lIvfd9LOVJwdovKOnJa4TLLrHxquK+DlGm4rkGmrcur+GRx+x4oW00O2pY/fFw==",
       "dev": true
     },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -5710,6 +5794,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",
@@ -6089,9 +6179,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "express-graphql": "^0.7.1",
     "graphql": "^14.1.1",
     "http-proxy": "^1.17.0",
-    "standard": "^12.0.1",
+    "standard": "^13.0.2",
     "tap": "^12.6.3",
     "tape-cluster": "^3.0.0"
   }

--- a/test/lib/mock-packages.js
+++ b/test/lib/mock-packages.js
@@ -6,10 +6,10 @@ module.exports =
   publishedAt: '2019-02-13T23:19:36.131Z',
   description: 'a package manager for JavaScript',
   author: 'audrey.e',
-  maintainers: [ 'audrey.e', 'fharper', 'iarna', 'isaacs', 'zkat' ],
-  keywords: [ 'install', 'modules', 'package manager', 'package.json' ],
+  maintainers: ['audrey.e', 'fharper', 'iarna', 'isaacs', 'zkat'],
+  keywords: ['install', 'modules', 'package manager', 'package.json'],
   scores:
-  [ { group: 'quality',
+  [{ group: 'quality',
     name: 'has-scm-info',
     pass: true,
     severity: 'NONE',
@@ -114,453 +114,453 @@ module.exports =
     pass: true,
     severity: 'NONE',
     title: 'This package version handles all callback errors.',
-    data: null } ]
+    data: null }]
 },
 {
-  'name': 'chalk',
-  'version': '2.4.2',
-  'published': true,
-  'publishedAt': '2019-01-05T15:45:52.349Z',
+  name: 'chalk',
+  version: '2.4.2',
+  published: true,
+  publishedAt: '2019-01-05T15:45:52.349Z',
   description: 'Terminal string styling done right',
   author: 'sindresorhus',
-  maintainers: [ 'qix', 'sindresorhus' ],
-  keywords: [ 'color', 'colour', 'colors' ],
-  'scores': [
+  maintainers: ['qix', 'sindresorhus'],
+  keywords: ['color', 'colour', 'colors'],
+  scores: [
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 10.8 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 10.8 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 48.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 48.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 7 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 7 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 2 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 2 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version has an unsafe regular expression at templates.js:2:24.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version has an unsafe regular expression at templates.js:2:24.',
+      data: {
+        locations: [
           'templates.js:2:24',
           'templates.js:3:21'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/chalk/chalk.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/chalk/chalk.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 96% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 96% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'ansi-styles',
-  'version': '3.2.1',
-  'published': true,
-  'publishedAt': '2018-03-02T09:40:00.702Z',
-  'scores': [
+  name: 'ansi-styles',
+  version: '3.2.1',
+  published: true,
+  publishedAt: '2018-03-02T09:40:00.702Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 3.7 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 3.7 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/sindresorhus/ansi-styles.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/sindresorhus/ansi-styles.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'color-convert',
-  'version': '1.9.3',
-  'published': true,
-  'publishedAt': '2018-08-28T05:32:39.014Z',
-  'scores': [
+  name: 'color-convert',
+  version: '1.9.3',
+  published: true,
+  publishedAt: '2018-08-28T05:32:39.014Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 2.9 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 2.9 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 48.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 48.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 7 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 7 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/Qix-/color-convert.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/Qix-/color-convert.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 71% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 71% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1',
           'route.js:1:1',
           'conversions.js:2:1'
@@ -570,751 +570,751 @@ module.exports =
   ]
 },
 {
-  'name': 'color-name',
-  'version': '1.1.3',
-  'published': true,
-  'publishedAt': '2017-07-15T22:17:08.140Z',
-  'scores': [
+  name: 'color-name',
+  version: '1.1.3',
+  published: true,
+  publishedAt: '2017-07-15T22:17:08.140Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 36.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 36.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 7 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 7 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+ssh://git@github.com/dfcreative/color-name.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+ssh://git@github.com/dfcreative/color-name.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 0% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 0% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version has a README file of 384 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version has a README file of 384 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     }
   ]
 },
 {
-  'name': 'escape-string-regexp',
-  'version': '1.0.5',
-  'published': true,
-  'publishedAt': '2016-02-21T12:55:17.074Z',
-  'scores': [
+  name: 'escape-string-regexp',
+  version: '1.0.5',
+  published: true,
+  publishedAt: '2016-02-21T12:55:17.074Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/sindresorhus/escape-string-regexp .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/sindresorhus/escape-string-regexp .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 552 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 552 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     }
   ]
 },
 {
-  'name': 'supports-color',
-  'version': '5.5.0',
-  'published': true,
-  'publishedAt': '2018-08-20T04:37:37.309Z',
-  'scores': [
+  name: 'supports-color',
+  version: '5.5.0',
+  published: true,
+  publishedAt: '2018-08-20T04:37:37.309Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/chalk/supports-color.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/chalk/supports-color.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 97% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 97% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 24.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 24.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 5 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 5 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 1.9 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 1.9 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     }
   ]
 },
 {
-  'name': 'has-flag',
-  'version': '3.0.0',
-  'published': true,
-  'publishedAt': '2018-01-02T19:21:56.098Z',
-  'scores': [
+  name: 'has-flag',
+  version: '3.0.0',
+  published: true,
+  publishedAt: '2018-01-02T19:21:56.098Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/sindresorhus/has-flag.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/sindresorhus/has-flag.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 986 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 986 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     }
   ]
 },
 {
-  'name': 'debug',
-  'version': '2.2.0',
-  'published': true,
-  'publishedAt': '2015-05-10T07:21:25.639Z',
-  'scores': [
+  name: 'debug',
+  version: '2.2.0',
+  published: true,
+  publishedAt: '2015-05-10T07:21:25.639Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version\'s size on disk is 60.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version\'s size on disk is 60.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 11 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 11 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version uses a deprecated Node API at node.js:164:20 — \'fs.SyncWriteStream\' was deprecated since v4.0.0.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version uses a deprecated Node API at node.js:164:20 — \'fs.SyncWriteStream\' was deprecated since v4.0.0.',
+      data: {
+        locations: [
           'node.js:164:20'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 6.3 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 6.3 kB.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/visionmedia/debug.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/visionmedia/debug.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 97% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 97% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in node.js:6:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in node.js:6:1.',
+      data: {
+        locations: [
           'node.js:6:1',
           'debug.js:9:1'
         ]
       }
     },
     {
-      'group': 'security',
-      'name': 'vulnerability',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'Regular Expression Denial of Service (ReDoS)',
-      'data': {
-        'id': 'npm:debug:20170905',
-        'vulnerable': [
+      group: 'security',
+      name: 'vulnerability',
+      pass: false,
+      severity: 'LOW',
+      title: 'Regular Expression Denial of Service (ReDoS)',
+      data: {
+        id: 'npm:debug:20170905',
+        vulnerable: [
           '>=1.0.0 <2.6.9',
           '>=3.0.0 <3.1.0'
         ]
@@ -1323,166 +1323,166 @@ module.exports =
   ]
 },
 {
-  'name': 'ms',
-  'version': '0.7.1',
-  'published': true,
-  'publishedAt': '2015-04-20T23:38:57.957Z',
-  'scores': [
+  name: 'ms',
+  version: '0.7.1',
+  published: true,
+  publishedAt: '2015-04-20T23:38:57.957Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 28.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 28.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 6 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 6 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 933 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 933 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version has an unsafe regular expression at index.js:43:15.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version has an unsafe regular expression at index.js:43:15.',
+      data: {
+        locations: [
           'index.js:43:15'
         ]
       }
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version has no license.',
-      'data': {
-        'spdx': null
+      group: 'compliance',
+      name: 'license',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version has no license.',
+      data: {
+        spdx: null
       }
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/guille/ms.js.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/guille/ms.js.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 88% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 88% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:5:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:5:1.',
+      data: {
+        locations: [
           'index.js:5:1'
         ]
       }
     },
     {
-      'group': 'security',
-      'name': 'vulnerability',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'Regular Expression Denial of Service (ReDoS)',
-      'data': {
-        'id': 'npm:ms:20170412',
-        'vulnerable': [
+      group: 'security',
+      name: 'vulnerability',
+      pass: false,
+      severity: 'LOW',
+      title: 'Regular Expression Denial of Service (ReDoS)',
+      data: {
+        id: 'npm:ms:20170412',
+        vulnerable: [
           '<2.0.0'
         ]
       }
@@ -1490,154 +1490,154 @@ module.exports =
   ]
 },
 {
-  'name': 'handlebars',
-  'version': '4.0.5',
-  'published': true,
-  'publishedAt': '2015-11-20T05:07:09.574Z',
-  'scores': [
+  name: 'handlebars',
+  version: '4.0.5',
+  published: true,
+  publishedAt: '2015-11-20T05:07:09.574Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'CRITICAL',
-      'title': 'This package version\'s size on disk is 2.7 MB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'CRITICAL',
+      title: 'This package version\'s size on disk is 2.7 MB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 113 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 113 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 19 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 19 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 8.5 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 8.5 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in lib/index.js:7:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in lib/index.js:7:1.',
+      data: {
+        locations: [
           'lib/index.js:7:1',
           'bin/handlebars:3:1'
         ]
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/wycats/handlebars.js.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/wycats/handlebars.js.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version uses a deprecated Node API at lib/index.js:22:39 — \'require.extensions\' was deprecated since v0.12.0. Use compiling them ahead of time instead.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version uses a deprecated Node API at lib/index.js:22:39 — \'require.extensions\' was deprecated since v0.12.0. Use compiling them ahead of time instead.',
+      data: {
+        locations: [
           'lib/index.js:22:39',
           'lib/index.js:23:3',
           'lib/index.js:24:3'
@@ -1645,14 +1645,14 @@ module.exports =
       }
     },
     {
-      'group': 'security',
-      'name': 'vulnerability',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'Prototype Pollution',
-      'data': {
-        'id': 'SNYK-JS-HANDLEBARS-173692',
-        'vulnerable': [
+      group: 'security',
+      name: 'vulnerability',
+      pass: false,
+      severity: 'HIGH',
+      title: 'Prototype Pollution',
+      data: {
+        id: 'SNYK-JS-HANDLEBARS-173692',
+        vulnerable: [
           '<4.0.13'
         ]
       }
@@ -1660,149 +1660,149 @@ module.exports =
   ]
 },
 {
-  'name': 'async',
-  'version': '1.5.2',
-  'published': true,
-  'publishedAt': '2016-01-08T00:03:32.998Z',
-  'scores': [
+  name: 'async',
+  version: '1.5.2',
+  published: true,
+  publishedAt: '2016-01-08T00:03:32.998Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version\'s size on disk is 184.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version\'s size on disk is 184.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 7 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 7 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 3 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 3 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 60.8 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 60.8 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/caolan/async.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/caolan/async.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 86% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 86% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in lib/async.js:8:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in lib/async.js:8:1.',
+      data: {
+        locations: [
           'lib/async.js:8:1'
         ]
       }
@@ -1810,304 +1810,304 @@ module.exports =
   ]
 },
 {
-  'name': 'optimist',
-  'version': '0.6.1',
-  'published': true,
-  'publishedAt': '2014-02-06T05:40:56.954Z',
-  'scores': [
+  name: 'optimist',
+  version: '0.6.1',
+  published: true,
+  publishedAt: '2014-02-06T05:40:56.954Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version\'s size on disk is 160.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version\'s size on disk is 160.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 29 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 29 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 10.7 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 10.7 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT/X11\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT/X11\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/substack/node-optimist.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/substack/node-optimist.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 33% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 33% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'minimist',
-  'version': '0.0.10',
-  'published': true,
-  'publishedAt': '2014-05-11T21:43:10.663Z',
-  'scores': [
+  name: 'minimist',
+  version: '0.0.10',
+  published: true,
+  publishedAt: '2014-05-11T21:43:10.663Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/substack/minimist.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/substack/minimist.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 95% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 95% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version\'s size on disk is 84.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version\'s size on disk is 84.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 16 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 16 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 3 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 3 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 1.6 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 1.6 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version has an unsafe regular expression at index.js:96:20.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version has an unsafe regular expression at index.js:96:20.',
+      data: {
+        locations: [
           'index.js:96:20',
           'index.js:185:12'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
@@ -2115,299 +2115,299 @@ module.exports =
   ]
 },
 {
-  'name': 'wordwrap',
-  'version': '0.0.3',
-  'published': true,
-  'publishedAt': '2015-05-07T17:04:58.219Z',
-  'scores': [
+  name: 'wordwrap',
+  version: '0.0.3',
+  published: true,
+  publishedAt: '2015-05-07T17:04:58.219Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 1.8 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 1.8 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/substack/node-wordwrap.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/substack/node-wordwrap.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 25% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 25% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version\'s size on disk is 72.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version\'s size on disk is 72.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 9 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 9 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 3 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 3 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     }
   ]
 },
 {
-  'name': 'source-map',
-  'version': '0.4.4',
-  'published': true,
-  'publishedAt': '2015-07-13T19:07:44.340Z',
-  'scores': [
+  name: 'source-map',
+  version: '0.4.4',
+  published: true,
+  publishedAt: '2015-07-13T19:07:44.340Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 15.9 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 15.9 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version\'s size on disk is 196.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version\'s size on disk is 196.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 22 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 22 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'BSD-3-Clause\'',
-      'data': {
-        'spdx': 'BSD-3-Clause'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'BSD-3-Clause\'',
+      data: {
+        spdx: 'BSD-3-Clause'
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at http://github.com/mozilla/source-map.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at http://github.com/mozilla/source-map.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 71% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 71% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in lib/source-map.js:6:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in lib/source-map.js:6:1.',
+      data: {
+        locations: [
           'lib/source-map.js:6:1'
         ]
       }
@@ -2415,304 +2415,304 @@ module.exports =
   ]
 },
 {
-  'name': 'amdefine',
-  'version': '1.0.1',
-  'published': true,
-  'publishedAt': '2016-11-02T05:00:51.414Z',
-  'scores': [
+  name: 'amdefine',
+  version: '1.0.1',
+  published: true,
+  publishedAt: '2016-11-02T05:00:51.414Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 36.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 36.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 5 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 5 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 6.1 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 6.1 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'BSD-3-Clause OR MIT\'',
-      'data': {
-        'spdx': 'BSD-3-Clause OR MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'BSD-3-Clause OR MIT\'',
+      data: {
+        spdx: 'BSD-3-Clause OR MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in amdefine.js:22:5.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in amdefine.js:22:5.',
+      data: {
+        locations: [
           'amdefine.js:22:5'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version does not have a scm repository specified.',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version does not have a scm repository specified.',
+      data: null
     }
   ]
 },
 {
-  'name': 'uglify-js',
-  'version': '2.8.29',
-  'published': true,
-  'publishedAt': '2017-06-14T03:43:13.026Z',
-  'scores': [
+  name: 'uglify-js',
+  version: '2.8.29',
+  published: true,
+  publishedAt: '2017-06-14T03:43:13.026Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 41.9 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 41.9 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version\'s size on disk is 660.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version\'s size on disk is 660.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 19 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 19 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version does eval at tools/node.js:27:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'uses-eval',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version does eval at tools/node.js:27:1.',
+      data: {
+        locations: [
           'tools/node.js:27:1'
         ]
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at https://github.com/mishoo/UglifyJS2.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at https://github.com/mishoo/UglifyJS2.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 85% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 85% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version uses a deprecated Node API at tools/node.js:44:23 — \'new Buffer()\' was deprecated since v6.0.0. Use \'Buffer.alloc()\' or \'Buffer.from()\' instead.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version uses a deprecated Node API at tools/node.js:44:23 — \'new Buffer()\' was deprecated since v6.0.0. Use \'Buffer.alloc()\' or \'Buffer.from()\' instead.',
+      data: {
+        locations: [
           'tools/node.js:44:23',
           'tools/node.js:171:86'
         ]
       }
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'BSD-2-Clause\'',
-      'data': {
-        'spdx': 'BSD-2-Clause'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'BSD-2-Clause\'',
+      data: {
+        spdx: 'BSD-2-Clause'
       }
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in tools/node.js:2:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in tools/node.js:2:1.',
+      data: {
+        locations: [
           'tools/node.js:2:1'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version has an unsafe regular expression at tools/node.js:39:17.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version has an unsafe regular expression at tools/node.js:39:17.',
+      data: {
+        locations: [
           'tools/node.js:39:17'
         ]
       }
@@ -2720,154 +2720,154 @@ module.exports =
   ]
 },
 {
-  'name': 'source-map',
-  'version': '0.5.7',
-  'published': true,
-  'publishedAt': '2017-08-21T16:30:15.907Z',
-  'scores': [
+  name: 'source-map',
+  version: '0.5.7',
+  published: true,
+  publishedAt: '2017-08-21T16:30:15.907Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version\'s size on disk is 800.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version\'s size on disk is 800.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 19 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 19 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 3 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 3 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 23.5 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 23.5 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version has an unsafe regular expression at lib/util.js:29:17.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version has an unsafe regular expression at lib/util.js:29:17.',
+      data: {
+        locations: [
           'lib/util.js:29:17',
           'lib/util.js:216:21'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'BSD-3-Clause\'',
-      'data': {
-        'spdx': 'BSD-3-Clause'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'BSD-3-Clause\'',
+      data: {
+        spdx: 'BSD-3-Clause'
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at http://github.com/mozilla/source-map.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at http://github.com/mozilla/source-map.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 71% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 71% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in source-map.js:6:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in source-map.js:6:1.',
+      data: {
+        locations: [
           'source-map.js:6:1',
           'lib/base64-vlq.js:38:1',
           'lib/util.js:18:1',
@@ -2879,300 +2879,300 @@ module.exports =
   ]
 },
 {
-  'name': 'uglify-to-browserify',
-  'version': '1.0.2',
-  'published': true,
-  'publishedAt': '2014-02-05T12:40:02.383Z',
-  'scores': [
+  name: 'uglify-to-browserify',
+  version: '1.0.2',
+  published: true,
+  publishedAt: '2014-02-05T12:40:02.383Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at https://github.com/ForbesLindesay/uglify-to-browserify.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at https://github.com/ForbesLindesay/uglify-to-browserify.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 574 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 574 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 36.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 36.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 7 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 7 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 2 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 2 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     }
   ]
 },
 {
-  'name': 'yargs',
-  'version': '3.10.0',
-  'published': true,
-  'publishedAt': '2015-05-29T04:32:16.617Z',
-  'scores': [
+  name: 'yargs',
+  version: '3.10.0',
+  published: true,
+  publishedAt: '2015-05-29T04:32:16.617Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'HIGH',
-      'title': 'This package version\'s size on disk is 132.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'HIGH',
+      title: 'This package version\'s size on disk is 132.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 10 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 10 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 2 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 2 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version has an unsafe regular expression at lib/parser.js:174:12.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version has an unsafe regular expression at lib/parser.js:174:12.',
+      data: {
+        locations: [
           'lib/parser.js:174:12',
           'lib/parser.js:440:12'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 22.3 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 22.3 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/yargs/yargs.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/yargs/yargs.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 87% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 87% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1',
           'lib/parser.js:3:1',
           'lib/validation.js:3:1',
@@ -3184,295 +3184,295 @@ module.exports =
   ]
 },
 {
-  'name': 'camelcase',
-  'version': '1.2.1',
-  'published': true,
-  'publishedAt': '2015-08-01T10:38:13.833Z',
-  'scores': [
+  name: 'camelcase',
+  version: '1.2.1',
+  published: true,
+  publishedAt: '2015-08-01T10:38:13.833Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 889 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 889 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/sindresorhus/camelcase.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/sindresorhus/camelcase.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 94% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 94% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'cliui',
-  'version': '2.1.0',
-  'published': true,
-  'publishedAt': '2015-04-24T22:35:03.777Z',
-  'scores': [
+  name: 'cliui',
+  version: '2.1.0',
+  published: true,
+  publishedAt: '2015-04-24T22:35:03.777Z',
+  scores: [
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'ISC\'',
-      'data': {
-        'spdx': 'ISC'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'ISC\'',
+      data: {
+        spdx: 'ISC'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version\'s size on disk is 52.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version\'s size on disk is 52.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 8 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 8 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 2 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 2 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+ssh://git@github.com/bcoe/cliui.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+ssh://git@github.com/bcoe/cliui.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 94% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 94% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 2.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 2.0 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
@@ -3480,441 +3480,441 @@ module.exports =
   ]
 },
 {
-  'name': 'center-align',
-  'version': '0.1.3',
-  'published': true,
-  'publishedAt': '2016-02-01T22:42:21.133Z',
-  'scores': [
+  name: 'center-align',
+  version: '0.1.3',
+  published: true,
+  publishedAt: '2016-02-01T22:42:21.133Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 24.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 24.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 5 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 5 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 1.9 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 1.9 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/jonschlinkert/center-align.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/jonschlinkert/center-align.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 50% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 50% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'align-text',
-  'version': '0.1.4',
-  'published': true,
-  'publishedAt': '2016-02-02T01:50:57.618Z',
-  'scores': [
+  name: 'align-text',
+  version: '0.1.4',
+  published: true,
+  publishedAt: '2016-02-02T01:50:57.618Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/jonschlinkert/align-text.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/jonschlinkert/align-text.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 50% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 50% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 24.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 24.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 5.5 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 5.5 kB.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     }
   ]
 },
 {
-  'name': 'kind-of',
-  'version': '3.2.2',
-  'published': true,
-  'publishedAt': '2017-05-16T18:21:41.452Z',
-  'scores': [
+  name: 'kind-of',
+  version: '3.2.2',
+  published: true,
+  publishedAt: '2017-05-16T18:21:41.452Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/jonschlinkert/kind-of.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/jonschlinkert/kind-of.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 80% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 80% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 8.1 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 8.1 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 24.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 24.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
@@ -3922,149 +3922,149 @@ module.exports =
   ]
 },
 {
-  'name': 'is-buffer',
-  'version': '1.1.6',
-  'published': true,
-  'publishedAt': '2017-10-25T21:36:28.871Z',
-  'scores': [
+  name: 'is-buffer',
+  version: '1.1.6',
+  published: true,
+  publishedAt: '2017-10-25T21:36:28.871Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 28.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 28.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 5 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 5 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 2 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 2 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 1.7 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 1.7 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/feross/is-buffer.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/feross/is-buffer.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:10:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:10:1.',
+      data: {
+        locations: [
           'index.js:10:1'
         ]
       }
@@ -4072,1151 +4072,1151 @@ module.exports =
   ]
 },
 {
-  'name': 'longest',
-  'version': '1.0.1',
-  'published': true,
-  'publishedAt': '2015-03-31T11:38:21.482Z',
-  'scores': [
+  name: 'longest',
+  version: '1.0.1',
+  published: true,
+  publishedAt: '2015-03-31T11:38:21.482Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 2.2 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 2.2 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at https://github.com/jonschlinkert/longest.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at https://github.com/jonschlinkert/longest.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 80% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 80% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: {\'url\':\'https://github.com/jonschlinkert/longest/blob/master/LICENSE\',\'type\':\'MIT\'}',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: {\'url\':\'https://github.com/jonschlinkert/longest/blob/master/LICENSE\',\'type\':\'MIT\'}',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     }
   ]
 },
 {
-  'name': 'repeat-string',
-  'version': '1.6.1',
-  'published': true,
-  'publishedAt': '2016-10-23T16:54:00.613Z',
-  'scores': [
+  name: 'repeat-string',
+  version: '1.6.1',
+  published: true,
+  publishedAt: '2016-10-23T16:54:00.613Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 24.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 24.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 5.1 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 5.1 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/jonschlinkert/repeat-string.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/jonschlinkert/repeat-string.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 24% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 24% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'lazy-cache',
-  'version': '1.0.4',
-  'published': true,
-  'publishedAt': '2016-04-23T02:34:21.150Z',
-  'scores': [
+  name: 'lazy-cache',
+  version: '1.0.4',
+  published: true,
+  publishedAt: '2016-04-23T02:34:21.150Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 3.7 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 3.7 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/jonschlinkert/lazy-cache.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/jonschlinkert/lazy-cache.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 65% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 65% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'right-align',
-  'version': '0.1.3',
-  'published': true,
-  'publishedAt': '2015-06-09T05:58:16.317Z',
-  'scores': [
+  name: 'right-align',
+  version: '0.1.3',
+  published: true,
+  publishedAt: '2015-06-09T05:58:16.317Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 2.1 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 2.1 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/jonschlinkert/right-align.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/jonschlinkert/right-align.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 25% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 25% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     }
   ]
 },
 {
-  'name': 'wordwrap',
-  'version': '0.0.2',
-  'published': true,
-  'publishedAt': '2011-08-26T10:17:09.949Z',
-  'scores': [
+  name: 'wordwrap',
+  version: '0.0.2',
+  published: true,
+  publishedAt: '2011-08-26T10:17:09.949Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 1.8 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 1.8 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version\'s size on disk is 72.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version\'s size on disk is 72.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 9 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 9 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 3 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 3 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/substack/node-wordwrap.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/substack/node-wordwrap.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 25% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 25% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT/X11\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT/X11\'',
+      data: {
+        spdx: 'MIT'
       }
     }
   ]
 },
 {
-  'name': 'decamelize',
-  'version': '1.2.0',
-  'published': true,
-  'publishedAt': '2016-03-05T08:49:10.462Z',
-  'scores': [
+  name: 'decamelize',
+  version: '1.2.0',
+  published: true,
+  publishedAt: '2016-03-05T08:49:10.462Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 781 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 781 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at https://github.com/sindresorhus/decamelize .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at https://github.com/sindresorhus/decamelize .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     }
   ]
 },
 {
-  'name': 'window-size',
-  'version': '0.1.0',
-  'published': true,
-  'publishedAt': '2014-02-15T03:41:48.322Z',
-  'scores': [
+  name: 'window-size',
+  version: '0.1.0',
+  published: true,
+  publishedAt: '2014-02-15T03:41:48.322Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 624 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 624 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/jonschlinkert/window-size.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/jonschlinkert/window-size.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 70% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 70% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 4 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 4 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:9:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:9:1.',
+      data: {
+        locations: [
           'index.js:9:1'
         ]
       }
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: {\'url\':\'https://github.com/jonschlinkert/window-size/blob/master/LICENSE-MIT\',\'type\':\'MIT\'}',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: {\'url\':\'https://github.com/jonschlinkert/window-size/blob/master/LICENSE-MIT\',\'type\':\'MIT\'}',
+      data: {
+        spdx: 'MIT'
       }
     }
   ]
 },
 {
-  'name': 'brace-expansion',
-  'version': '1.1.2',
-  'published': true,
-  'publishedAt': '2015-11-28T12:58:57.647Z',
-  'scores': [
+  name: 'brace-expansion',
+  version: '1.1.2',
+  published: true,
+  publishedAt: '2015-11-28T12:58:57.647Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 3.5 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 3.5 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 28.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 28.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 5 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 5 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version has an unsafe regular expression at index.js:96:27.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version has an unsafe regular expression at index.js:96:27.',
+      data: {
+        locations: [
           'index.js:96:27',
           'index.js:97:25',
           'index.js:99:19'
@@ -5224,46 +5224,46 @@ module.exports =
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/juliangruber/brace-expansion.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/juliangruber/brace-expansion.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 93% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 93% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'security',
-      'name': 'vulnerability',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'Regular Expression Denial of Service (ReDoS)',
-      'data': {
-        'id': 'npm:brace-expansion:20170302',
-        'vulnerable': [
+      group: 'security',
+      name: 'vulnerability',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'Regular Expression Denial of Service (ReDoS)',
+      data: {
+        id: 'npm:brace-expansion:20170302',
+        vulnerable: [
           '<1.1.7'
         ]
       }
@@ -5271,739 +5271,739 @@ module.exports =
   ]
 },
 {
-  'name': 'balanced-match',
-  'version': '0.3.0',
-  'published': true,
-  'publishedAt': '2015-11-28T12:37:27.893Z',
-  'scores': [
+  name: 'balanced-match',
+  version: '0.3.0',
+  published: true,
+  publishedAt: '2015-11-28T12:37:27.893Z',
+  scores: [
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 3.1 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 3.1 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 44.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 44.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 9 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 9 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 2 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 2 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/juliangruber/balanced-match.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/juliangruber/balanced-match.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'concat-map',
-  'version': '0.0.1',
-  'published': true,
-  'publishedAt': '2014-01-30T03:06:35.982Z',
-  'scores': [
+  name: 'concat-map',
+  version: '0.0.1',
+  published: true,
+  publishedAt: '2014-01-30T03:06:35.982Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version doesn\'t use strict mode in index.js:1:1.',
-      'data': {
-        'locations': [
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version doesn\'t use strict mode in index.js:1:1.',
+      data: {
+        locations: [
           'index.js:1:1'
         ]
       }
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 40.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 40.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 7 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 7 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 3 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 3 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file of 1.2 kB.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file of 1.2 kB.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git://github.com/substack/node-concat-map.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git://github.com/substack/node-concat-map.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 50% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 50% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     }
   ]
 },
 {
-  'name': 'left-pad',
-  'version': '1.3.0',
-  'published': true,
-  'publishedAt': '2018-04-09T01:10:45.796Z',
-  'scores': [
+  name: 'left-pad',
+  version: '1.3.0',
+  published: true,
+  publishedAt: '2018-04-09T01:10:45.796Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 871 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 871 B.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 48.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 48.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 10 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 10 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 2 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 2 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version license is unacceptable: \'WTFPL\'',
-      'data': {
-        'spdx': 'WTFPL'
+      group: 'compliance',
+      name: 'license',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version license is unacceptable: \'WTFPL\'',
+      data: {
+        spdx: 'WTFPL'
       }
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+ssh://git@github.com/stevemao/left-pad.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+ssh://git@github.com/stevemao/left-pad.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package has 40% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package has 40% tagged non-prelease versions in git.',
+      data: null
     }
   ]
 },
 {
-  'name': 'is-path-in-cwd',
-  'version': null,
-  'published': false,
-  'publishedAt': null,
-  'scores': []
+  name: 'is-path-in-cwd',
+  version: null,
+  published: false,
+  publishedAt: null,
+  scores: []
 },
 {
-  'name': 'is-path-inside',
-  'version': '2.1.0',
-  'published': true,
-  'publishedAt': '2019-04-15T16:33:19.419Z',
-  'scores': [
+  name: 'is-path-inside',
+  version: '2.1.0',
+  published: true,
+  publishedAt: '2019-04-15T16:33:19.419Z',
+  scores: [
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'MIT\'',
-      'data': {
-        'spdx': 'MIT'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'MIT\'',
+      data: {
+        spdx: 'MIT'
       }
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/sindresorhus/is-path-inside.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/sindresorhus/is-path-inside.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 100% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 100% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version has a README file of 591 B.',
-      'data': null
+      group: 'quality',
+      name: 'readme-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version has a README file of 591 B.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 24.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 24.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 5 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 5 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 1 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 1 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     }
   ]
 },
 {
-  'name': 'path-is-inside',
-  'version': '1.0.2',
-  'published': true,
-  'publishedAt': '2016-09-10T23:35:10.802Z',
-  'scores': [
+  name: 'path-is-inside',
+  version: '1.0.2',
+  published: true,
+  publishedAt: '2016-09-10T23:35:10.802Z',
+  scores: [
     {
-      'group': 'risk',
-      'name': 'deprecated',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version is not deprecated.',
-      'data': null
+      group: 'risk',
+      name: 'deprecated',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version is not deprecated.',
+      data: null
     },
     {
-      'group': 'compliance',
-      'name': 'license',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version license is acceptable: \'(WTFPL OR MIT)\'',
-      'data': {
-        'spdx': '(WTFPL OR MIT)'
+      group: 'compliance',
+      name: 'license',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version license is acceptable: \'(WTFPL OR MIT)\'',
+      data: {
+        spdx: '(WTFPL OR MIT)'
       }
     },
     {
-      'group': 'quality',
-      'name': 'has-scm-info',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version has a git repository at git+https://github.com/domenic/path-is-inside.git .',
-      'data': null
+      group: 'quality',
+      name: 'has-scm-info',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version has a git repository at git+https://github.com/domenic/path-is-inside.git .',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'scm-tagged-versions',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 67% tagged non-prelease versions in git.',
-      'data': null
+      group: 'quality',
+      name: 'scm-tagged-versions',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 67% tagged non-prelease versions in git.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-eval',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use eval() or implied eval.',
-      'data': null
+      group: 'risk',
+      name: 'uses-eval',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use eval() or implied eval.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-abandoned-promises',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version finalizes all detectable promises.',
-      'data': null
+      group: 'risk',
+      name: 'has-abandoned-promises',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version finalizes all detectable promises.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-lost-callback-errs',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version handles all callback errors.',
-      'data': null
+      group: 'risk',
+      name: 'has-lost-callback-errs',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version handles all callback errors.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'readme-exists',
-      'pass': false,
-      'severity': 'MEDIUM',
-      'title': 'This package version does not have a README file.',
-      'data': null
+      group: 'quality',
+      name: 'readme-exists',
+      pass: false,
+      severity: 'MEDIUM',
+      title: 'This package version does not have a README file.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-expanded-size',
-      'pass': false,
-      'severity': 'LOW',
-      'title': 'This package version\'s size on disk is 20.0 kB.',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-expanded-size',
+      pass: false,
+      severity: 'LOW',
+      title: 'This package version\'s size on disk is 20.0 kB.',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-file-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 3 file(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-file-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 3 file(s).',
+      data: null
     },
     {
-      'group': 'quality',
-      'name': 'disk-usage-dir-count',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package has 2 dir(s).',
-      'data': null
+      group: 'quality',
+      name: 'disk-usage-dir-count',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package has 2 dir(s).',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-install-scripts',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have install scripts.',
-      'data': null
+      group: 'risk',
+      name: 'has-install-scripts',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have install scripts.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-gyp-file',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have a Gyp build file.',
-      'data': null
+      group: 'risk',
+      name: 'has-gyp-file',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have a Gyp build file.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'has-unsafe-regexps',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not have unsafe regular expressions.',
-      'data': null
+      group: 'risk',
+      name: 'has-unsafe-regexps',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not have unsafe regular expressions.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'missing-strict-mode',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version always uses strict mode.',
-      'data': null
+      group: 'risk',
+      name: 'missing-strict-mode',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version always uses strict mode.',
+      data: null
     },
     {
-      'group': 'risk',
-      'name': 'uses-deprecated-node-apis',
-      'pass': true,
-      'severity': 'NONE',
-      'title': 'This package version does not use any deprecated Node APIs.',
-      'data': null
+      group: 'risk',
+      name: 'uses-deprecated-node-apis',
+      pass: true,
+      severity: 'NONE',
+      title: 'This package version does not use any deprecated Node APIs.',
+      data: null
     }
   ]
 }]

--- a/test/lib/test-runner.js
+++ b/test/lib/test-runner.js
@@ -181,7 +181,7 @@ function NCMAPI (mockData) {
 }
 
 NCMAPI.prototype.packageVersion = function packageVersion (params) {
-  let modules = this.mockData.packages.filter(function findPackage (p) {
+  const modules = this.mockData.packages.filter(function findPackage (p) {
     return p.name === params.name &&
       p.version === params.version
   })
@@ -197,9 +197,9 @@ NCMAPI.prototype.packageVersion = function packageVersion (params) {
 }
 
 NCMAPI.prototype.packageVersions = function packageVersions (params) {
-  let versions = params.packageVersions
+  const versions = params.packageVersions
 
-  let modules = this.mockData.packages.filter(function findPackage (p) {
+  const modules = this.mockData.packages.filter(function findPackage (p) {
     return versions.some(function (v) {
       // For this module return the bad data object
       if (v.name === p.name && p.name === 'is-path-in-cwd') {
@@ -220,7 +220,7 @@ NCMAPI.prototype.policies = function policies (params) {
     name,
     organizationId,
     whitelist: [...whitelist.values()].map(pkgver => {
-      let [name, version] = reversedSplit(pkgver, /@(?!$)/)
+      const [name, version] = reversedSplit(pkgver, /@(?!$)/)
       return { name, version }
     })
   }]

--- a/test/proxied.js
+++ b/test/proxied.js
@@ -33,7 +33,7 @@ NCMTestRunner.test('api requests respect ENV proxy settings', async (runner, t) 
   })
 
   // Have the proxy server ipc us its port
-  const [ procPort ] = await once(proc, 'message')
+  const [procPort] = await once(proc, 'message')
 
   try {
     await runner.execP('details npm @ 6.8.0', {

--- a/test/report.js
+++ b/test/report.js
@@ -127,7 +127,7 @@ TestRunner.test('report --filter=security output', (runner, t) =>
 )
 
 TestRunner.test('report --filter=high --security output', (runner, t) => {
-  let cmd = `report ${MOCK_PROJECT} --filter=high --security`
+  const cmd = `report ${MOCK_PROJECT} --filter=high --security`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')
@@ -148,7 +148,7 @@ TestRunner.test('report --filter=high --security output', (runner, t) => {
 })
 
 TestRunner.test('report --filter=high output', (runner, t) => {
-  let cmd = `report ${MOCK_PROJECT} --filter=high`
+  const cmd = `report ${MOCK_PROJECT} --filter=high`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')
@@ -169,7 +169,7 @@ TestRunner.test('report --filter=high output', (runner, t) => {
 })
 
 TestRunner.test('report --filter=h output', (runner, t) => {
-  let cmd = `report ${MOCK_PROJECT} --filter=h --color=16m`
+  const cmd = `report ${MOCK_PROJECT} --filter=h --color=16m`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')
@@ -190,7 +190,7 @@ TestRunner.test('report --filter=h output', (runner, t) => {
 })
 
 TestRunner.test('report --filter=high,security output', (runner, t) => {
-  let cmd = `report ${MOCK_PROJECT} --filter=high,security`
+  const cmd = `report ${MOCK_PROJECT} --filter=high,security`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')
@@ -211,7 +211,7 @@ TestRunner.test('report --filter=high,security output', (runner, t) => {
 })
 
 TestRunner.test('report --filter=medium --security output', (runner, t) => {
-  let cmd = `report ${MOCK_PROJECT} --filter=medium --security`
+  const cmd = `report ${MOCK_PROJECT} --filter=medium --security`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')
@@ -232,7 +232,7 @@ TestRunner.test('report --filter=medium --security output', (runner, t) => {
 })
 
 TestRunner.test('report --filter=m --security output', (runner, t) => {
-  let cmd = `report ${MOCK_PROJECT} --filter=m --security`
+  const cmd = `report ${MOCK_PROJECT} --filter=m --security`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')
@@ -253,7 +253,7 @@ TestRunner.test('report --filter=m --security output', (runner, t) => {
 })
 
 TestRunner.test('report --filter=low --security output', (runner, t) => {
-  let cmd = `report ${MOCK_PROJECT} --filter=low --security`
+  const cmd = `report ${MOCK_PROJECT} --filter=low --security`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')
@@ -274,7 +274,7 @@ TestRunner.test('report --filter=low --security output', (runner, t) => {
 })
 
 TestRunner.test('report --filter=l --security output', (runner, t) => {
-  let cmd = `report ${MOCK_PROJECT} --filter=l --security`
+  const cmd = `report ${MOCK_PROJECT} --filter=l --security`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')
@@ -306,7 +306,7 @@ TestRunner.test('report output matches snapshot', (runner, t) =>
 )
 
 TestRunner.test('report with poisoned project', (runner, t) => {
-  let cmd = `report --long ${POISONED_PROJECT}`
+  const cmd = `report --long ${POISONED_PROJECT}`
   runner.exec(cmd, (err, stdout, stderr) => {
     t.equal(err.code, 1)
     t.equal(stderr, '')


### PR DESCRIPTION
I updated standard, ran `npx standard --fix` and manually fixed two errors. The most notable change is that standard now requires the use of `const` over `let` if the variable won't be reassigned.