### PR TITLE
details: ignore u-m-t error if ERR_ASSERTION

### DIFF
--- a/commands/details.js
+++ b/commands/details.js
@@ -62,7 +62,7 @@ async function details (argv, arg1, arg2, arg3) {
       }
     }
   } catch (err) {
-    if (err.code !== 'ENOENT') throw err
+    if (err.code !== 'ENOENT' && err.code !== 'ERR_ASSERTION') throw err
   }
 
   if (!name || (version !== 'latest' && !semver.valid(version))) {


### PR DESCRIPTION
universal-module-tree returns this instead of ENOENT for some reason...

Fixes https://github.com/nodesource/ncm-cli/issues/178