### PR TITLE
fix ncm report to make its risk score consistent

### DIFF
--- a/commands/report.js
+++ b/commands/report.js
@@ -162,7 +162,8 @@ async function report (argv, _dir) {
     }
 
     if (!version) {
-      version = '0.0.0-UNKNOWN-VERSION'
+      // skip unknown version to make the report consistent
+      continue
     }
 
     if (isNested && !!maxSeverity) {

--- a/lib/report/score.js
+++ b/lib/report/score.js
@@ -50,15 +50,14 @@ function score (pkgScores = []) {
       case 'risk':
         sevScore += calcSev(severity) * 2
         break
-      case 'quality':
-        sevScore += calcSev(severity)
-        break
       case 'compliance':
         sevScore += calcSev(severity)
         break
     }
 
-    if (!pass) {
+    // Quality scores do not affect a package’s risk level
+    // https://docs.nodesource.com/ncmv2/docs#quality-severity
+    if (!pass && group !== 'quality') {
       sevScore += scores[name] || 0
     }
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ncm-cli",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ncm-cli",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "license": "Apache-2.0",
   "description": "Command-line tool for NodeSource Certified Modules 2.0",
   "author": "NodeSource <npm@nodesource.com> (https://nodesource.com)",


### PR DESCRIPTION
- [x] skip unknown versions of packages to make the report consistent
- [x] make quality scores do not affect a package’s risk level since a quality criteria does not offset a security vulnerability or risk attribute, NCM 2 does not assign an impact severity to a quality attribute: https://docs.nodesource.com/ncmv2/docs#quality-severity