### PR TITLE
docs: update service token documentation link to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ ncm signin
 $ NCM_TOKEN=<token> ncm <command> [options]
 ```
 
-Learn more about obtaining NodeSource service tokens and configuring permissions [here](https://docs.nodesource.com/docs/ncm2/getting-started/#3-environment-variable-cicd).
+Learn more about obtaining NodeSource service tokens and configuring permissions [here](https://docs.nodesource.com/docs/accounts/saasdashboard).
 
 ## `ncm report`
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ ncm signin
 $ NCM_TOKEN=<token> ncm <command> [options]
 ```
 
-Learn more about obtaining NodeSource service tokens and configuring permissions [here](https://docs.nodesource.com/ncm_v2/docs#ci-setup).
+Learn more about obtaining NodeSource service tokens and configuring permissions [here](https://docs.nodesource.com/docs/ncm2/getting-started/#3-environment-variable-cicd).
 
 ## `ncm report`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Environment Variable (CI/CD) guidance link to the latest Getting Started/Accounts page so users reach current setup instructions.
  * No other text or examples changed; only the hyperlink target was refreshed.
  * Documentation-only change with no functional impact and low review overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->